### PR TITLE
Fix for :- Error handling bug issue #3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ module.exports = function(options) {
 
     var release = publishRelease(options, callback);
 
+    //handle emmitted errors
+    release.on('error', function(existingError) {
+      gutil.log(existingError);
+      this.emit('end');
+    });
+
     release.on('created-release', function() {
       gutil.log('Release created successfully at https://github.com/' + options.owner + '/' + options.repo + '/releases/tag/' + options.tag);
     });


### PR DESCRIPTION
The upstream dependency 'publish-release' also requires a fix to emit 'error' as it is an 'EventEmitter' I have created that PR too.

I have fixed #3 it needs a 'error' handler in this gulp plugin and a fix upstream in publish-release to emit errors and handle 400 -> 599 status codes.

When I now run the plugin with bad auth token it stops and gives me a message like this:-

`
[Error: Error status: 401  response body:{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}

 request details:{
  "uri": "https://api.github.com/repos/suited/suited.js/releases",
  "method": "POST",
  "json": true,
  "body": {
    "tag_name": "1.0.11-alpha",
    "name": "1.0.11-alpha",
    "body": "my release notes",
    "draft": false,
    "prerelease": false
  },
  "headers": {
    "Authorization": "token ff964mybogustoken",
    "User-Agent": "publish-release 1.3.1 (https://github.com/remixz/publish-release)"
  }
}]
`

ie shows me the error and the request that failed.

Cheers

Karl
